### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/src/bin/024.rs
+++ b/src/bin/024.rs
@@ -12,5 +12,5 @@ fn main() {
         .iter()
         .map(|&(p, q)| (q as f32) / (p as f32))
         .sum::<f32>();
-    println!("{:.?}", result);
+    println!("{:?}", result);
 }


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.